### PR TITLE
chore: update compile and target SDK to 34

### DIFF
--- a/codedapp_android_driver_new/app/build.gradle
+++ b/codedapp_android_driver_new/app/build.gradle
@@ -11,11 +11,11 @@ android {
             storePassword 'imota123'
         }
     }
-    compileSdkVersion 28
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.codedapp"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 14
         versionName "3.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/codedapp_android_driver_new/braintreepayment/build.gradle
+++ b/codedapp_android_driver_new/braintreepayment/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/codedapp_android_driver_new/paytmpayment/build.gradle
+++ b/codedapp_android_driver_new/paytmpayment/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/codedapp_android_driver_new/payumoneypayment/build.gradle
+++ b/codedapp_android_driver_new/payumoneypayment/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/codedapp_android_driver_new/stripepayment/build.gradle
+++ b/codedapp_android_driver_new/stripepayment/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/codedapp_android_user_new/app/build.gradle
+++ b/codedapp_android_user_new/app/build.gradle
@@ -11,11 +11,11 @@ android {
             storePassword 'imota123'
         }
     }
-    compileSdkVersion 28
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.codedapp"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 13
         versionName "3.0"
         multiDexEnabled true

--- a/codedapp_android_user_new/nativechekoutpaypal/build.gradle
+++ b/codedapp_android_user_new/nativechekoutpaypal/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/codedapp_android_user_new/paytmpayment/build.gradle
+++ b/codedapp_android_user_new/paytmpayment/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/codedapp_android_user_new/payumoneypayment/build.gradle
+++ b/codedapp_android_user_new/payumoneypayment/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/codedapp_android_user_new/stripepayment/build.gradle
+++ b/codedapp_android_user_new/stripepayment/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
## Summary
- update compile and target SDK versions to 34 across user and driver apps and payment modules

## Testing
- `./codedapp_android_driver_new/gradlew -q -p codedapp_android_driver_new --no-daemon help` *(fails: Unsupported class file major version 65)*
- `./codedapp_android_user_new/gradlew -q -p codedapp_android_user_new --no-daemon help` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5074afc083338a541936401b6fa8